### PR TITLE
Fix validation failures of jpg/jpeg files

### DIFF
--- a/src/CoverValidator.php
+++ b/src/CoverValidator.php
@@ -57,6 +57,6 @@ class CoverValidator extends AvatarValidator
      */
     protected function getAllowedTypes()
     {
-        return ['jpeg', 'png', 'bmp'];
+        return ['jpg', 'png', 'bmp'];
     }
 }


### PR DESCRIPTION
An update of symfony/mime renders the current validator incompatible. This issue is identical to the one from flarum/core's avatar uploader (https://github.com/flarum/core/pull/2497) and can be fixed in the same way. Confirmed lokally that the fix works.