### PR TITLE
ImageManager in constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
       "forum": "https://discuss.flarum.org/d/23437"
     },
     "require": {
-        "flarum/core": "^1.0.0"
+        "flarum/core": "^1.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/CoverValidator.php
+++ b/src/CoverValidator.php
@@ -15,6 +15,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\AvatarValidator;
 use Illuminate\Validation\Factory;
 use Illuminate\Contracts\Events\Dispatcher;
+use Intervention\Image\ImageManager;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CoverValidator extends AvatarValidator
@@ -27,9 +28,9 @@ class CoverValidator extends AvatarValidator
     /**
      * {@inheritdoc}
      */
-    public function __construct(Factory $validator, TranslatorInterface $translator, SettingsRepositoryInterface $config)
+    public function __construct(Factory $validator, TranslatorInterface $translator, ImageManager $imageManager, SettingsRepositoryInterface $config)
     {
-        parent::__construct($validator, $translator);
+        parent::__construct($validator, $translator, $imageManager);
 
         $this->config = $config;
     }


### PR DESCRIPTION
In Flarum 1.2, the `AvatarValidator` requires a 3rd param, `ImageManager`. 

To allow this extension to run on Flarum 1.2, this change is required