### PR TITLE
feat: add class to `UserCard` if image present

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -5,6 +5,7 @@ import UserCard from 'flarum/components/UserCard';
 import UserControls from 'flarum/utils/UserControls';
 import Button from 'flarum/components/Button';
 import Model from 'flarum/Model';
+import classList from 'flarum/common/utils/classList';
 
 import CoverEditorModal from './components/CoverEditorModal';
 
@@ -24,6 +25,8 @@ app.initializers.add('sycho-profile-cover', () => {
     if (this.attrs.controlsButtonClassName.includes('Button--icon') && thumbnailUrl) {
       coverUrl = thumbnailUrl;
     }
+
+    view.attrs.className = classList(view.attrs.className, 'UserCard--hasCoverImage');
 
     view.attrs.style = Object.assign(view.attrs.style, {
       '--background-image': `url(${coverUrl})`,


### PR DESCRIPTION
Adds an easy-to-use possibility to differentiate between UserCard's which don't have a cover image and those who do for CSS styling